### PR TITLE
Generalise port implementation for IP comms in addition to serial

### DIFF
--- a/comms/comms.go
+++ b/comms/comms.go
@@ -1,0 +1,34 @@
+package phocus_comms
+
+import (
+	"time"
+)
+
+type Serial struct {
+	Port    string
+	Baud    int
+	Retries int
+}
+type IP struct {
+	Host string
+	Port int
+}
+type ConnectionType string
+
+type Connection struct {
+	Type   ConnectionType
+	Serial *Serial `json:"Serial,omitempty"`
+	IP     *IP     `json:"IP,omitempty"`
+}
+
+const (
+	ConnectionTypeSerial ConnectionType = "Serial"
+	ConnectionTypeIP     ConnectionType = "IP"
+)
+
+type Port interface {
+	Open() (Port, error)
+	Close() error
+	Read(timeout time.Duration) (string, error)
+	Write(string) (int, error)
+}

--- a/comms/comms_test.go
+++ b/comms/comms_test.go
@@ -1,0 +1,126 @@
+package phocus_comms
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockPort is a mock implementation of the Port interface
+type MockPort struct {
+	mock.Mock
+}
+
+func (m *MockPort) Open() (Port, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(Port), args.Error(1)
+}
+
+func (m *MockPort) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockPort) Read(timeout time.Duration) (string, error) {
+	args := m.Called(timeout)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockPort) Write(data string) (int, error) {
+	args := m.Called(data)
+	return args.Int(0), args.Error(1)
+}
+
+func TestPort_Open(t *testing.T) {
+	mockPort := new(MockPort)
+	mockPort.On("Open").Return(mockPort, nil)
+
+	port, err := mockPort.Open()
+	assert.NoError(t, err)
+	assert.Equal(t, mockPort, port)
+
+	mockPort.AssertExpectations(t)
+}
+
+func TestPort_Close(t *testing.T) {
+	mockPort := new(MockPort)
+	mockPort.On("Close").Return(nil)
+
+	err := mockPort.Close()
+	assert.NoError(t, err)
+
+	mockPort.AssertExpectations(t)
+}
+
+func TestPort_Read(t *testing.T) {
+	mockPort := new(MockPort)
+	expectedData := "test data"
+	mockPort.On("Read", mock.AnythingOfType("time.Duration")).Return(expectedData, nil)
+
+	data, err := mockPort.Read(1 * time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, data)
+
+	mockPort.AssertExpectations(t)
+}
+
+func TestPort_Write(t *testing.T) {
+	mockPort := new(MockPort)
+	expectedBytes := 9
+	mockPort.On("Write", "test data").Return(expectedBytes, nil)
+
+	bytesWritten, err := mockPort.Write("test data")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBytes, bytesWritten)
+
+	mockPort.AssertExpectations(t)
+}
+
+func TestPort_Open_Error(t *testing.T) {
+	mockPort := new(MockPort)
+	mockPort.On("Open").Return(nil, errors.New("open error"))
+
+	port, err := mockPort.Open()
+	assert.Error(t, err)
+	assert.Nil(t, port)
+
+	mockPort.AssertExpectations(t)
+}
+
+func TestPort_Close_Error(t *testing.T) {
+	mockPort := new(MockPort)
+	mockPort.On("Close").Return(errors.New("close error"))
+
+	err := mockPort.Close()
+	assert.Error(t, err)
+
+	mockPort.AssertExpectations(t)
+}
+
+func TestPort_Read_Error(t *testing.T) {
+	mockPort := new(MockPort)
+	mockPort.On("Read", mock.AnythingOfType("time.Duration")).Return("", errors.New("read error"))
+
+	data, err := mockPort.Read(1 * time.Second)
+	assert.Error(t, err)
+	assert.Empty(t, data)
+
+	mockPort.AssertExpectations(t)
+}
+
+func TestPort_Write_Error(t *testing.T) {
+	mockPort := new(MockPort)
+	mockPort.On("Write", "test data").Return(0, errors.New("write error"))
+
+	bytesWritten, err := mockPort.Write("test data")
+	assert.Error(t, err)
+	assert.Equal(t, 0, bytesWritten)
+
+	mockPort.AssertExpectations(t)
+}

--- a/config.json.example
+++ b/config.json.example
@@ -1,8 +1,11 @@
 {
-  "Serial": {
-    "Port": "/dev/ttyUSB0",
-    "Baud": 2400,
-    "Retries": 5
+  "Connection": {
+    "Type": "Serial",
+    "Serial": {
+      "Port": "/dev/ttyUSB0",
+      "Baud": 2400,
+      "Retries": 5
+    }
   },
   "MQTT": {
     "Host": "192.168.1.1",

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,7 @@ github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 h1:aQKxg3+2p+IFXXg97M
 github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3/go.mod h1:9/etS5gpQq9BJsJMWg1wpLbfuSnkm8dPF6FdW2JXVhA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/ip/ip.go
+++ b/ip/ip.go
@@ -1,0 +1,58 @@
+// Package phocus_ip facilitates communication
+// over IP with an inverter
+package phocus_ip
+
+import (
+	"errors" // creating custom err messages
+	"time"   // timeouts
+
+	comms "github.com/wolffshots/phocus/v2/comms" // common types for comms
+	crc "github.com/wolffshots/phocus/v2/crc"     // checksum generation
+)
+
+type Port struct {
+	// Socket
+	Host    string
+	Port    int
+	Retries int
+}
+
+// Open opens a connection to the inverter.
+//
+// Returns the port or an error if the port fails to open.
+func (ip *Port) Open() (comms.Port, error) {
+	var err error
+	for i := 0; i < ip.Retries; i++ {
+		// TODO
+	}
+	return ip, err
+}
+
+// Close just closes the port
+//
+// Returns the error if there is one
+func (ip *Port) Close() error {
+
+	return nil // TODO
+}
+
+// Read from the open socket until reaching a carriage return, nil or nothing.
+// Takes a duration as an input and times out the read after that long.
+//
+// Returns the read string and the error
+func (ip *Port) Read(timeout time.Duration) (string, error) {
+
+	return "", nil // TODO
+}
+
+// Write a string to the socket
+// The input should just be the "payload" string as
+// the CRC is calculated and added to that in Write
+func (ip *Port) Write(input string) (int, error) {
+	_ = crc.Encode(input) // TODO use message
+	// if ip == nil {
+	return 0, errors.New("port is nil on write")
+	// }
+	// TODO
+	// return 0, nil
+}

--- a/ip/ip_test.go
+++ b/ip/ip_test.go
@@ -1,0 +1,1 @@
+package phocus_ip

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -8,15 +9,103 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseConfig(t *testing.T) {
-	configuration, err := ParseConfig("config.json.example")
+func TestParseConfigFromFile(t *testing.T) {
+	configuration, err := ParseConfigFromFile("config.json.example")
 	assert.NoError(t, err)
 	assert.Equal(t, "192.168.1.1", configuration.MQTT.Host)
 	assert.Equal(t, 1883, configuration.MQTT.Port)
 	assert.Equal(t, "go_phocus_client", configuration.MQTT.Client.Name)
-	assert.Equal(t, 2400, configuration.Serial.Baud)
-	assert.Equal(t, "/dev/ttyUSB0", configuration.Serial.Port)
-	assert.Equal(t, 5, configuration.Serial.Retries)
+	assert.Equal(t, 2400, configuration.Connection.Serial.Baud)
+	assert.Equal(t, "/dev/ttyUSB0", configuration.Connection.Serial.Port)
+	assert.Equal(t, 5, configuration.Connection.Serial.Retries)
+	assert.Equal(t, 5, configuration.MQTT.Retries)
+	assert.Equal(t, 2, configuration.Messages.Read.TimeoutSeconds)
+	assert.Equal(t, 2*time.Second, time.Duration(configuration.Messages.Read.TimeoutSeconds)*time.Second)
+	assert.Equal(t, 15, configuration.DelaySeconds)
+	assert.Equal(t, 5, configuration.RandDelaySeconds)
+	assert.Equal(t, 5, configuration.MinDelaySeconds)
+}
+
+func TestParseConfigSerial(t *testing.T) {
+	configJSON := `{
+        "Connection": {
+            "Serial": {
+                "Port": "/dev/ttyUSB0",
+                "Baud": 2400,
+                "Retries": 5
+            }
+        },
+        "MQTT": {
+            "Host": "192.168.1.1",
+            "Port": 1883,
+            "Client": {
+                "Name": "go_phocus_client"
+            },
+            "Retries": 5
+        },
+        "Messages": {
+            "Read": {
+                "TimeoutSeconds": 2
+            }
+        },
+        "DelaySeconds": 15,
+        "RandDelaySeconds": 5,
+        "MinDelaySeconds": 5,
+        "Profiling": false
+    }`
+
+	reader := strings.NewReader(configJSON)
+	configuration, err := ParseConfig(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, "192.168.1.1", configuration.MQTT.Host)
+	assert.Equal(t, 1883, configuration.MQTT.Port)
+	assert.Equal(t, "go_phocus_client", configuration.MQTT.Client.Name)
+	assert.Equal(t, 2400, configuration.Connection.Serial.Baud)
+	assert.Equal(t, "/dev/ttyUSB0", configuration.Connection.Serial.Port)
+	assert.Equal(t, 5, configuration.Connection.Serial.Retries)
+	assert.Equal(t, 5, configuration.MQTT.Retries)
+	assert.Equal(t, 2, configuration.Messages.Read.TimeoutSeconds)
+	assert.Equal(t, 2*time.Second, time.Duration(configuration.Messages.Read.TimeoutSeconds)*time.Second)
+	assert.Equal(t, 15, configuration.DelaySeconds)
+	assert.Equal(t, 5, configuration.RandDelaySeconds)
+	assert.Equal(t, 5, configuration.MinDelaySeconds)
+}
+
+func TestParseConfigIP(t *testing.T) {
+	configJSON := `{
+        "Connection": {
+            "IP": {
+                "Host": "example.com",
+                "Port": 1080
+            }
+        },
+        "MQTT": {
+            "Host": "192.168.1.1",
+            "Port": 1883,
+            "Client": {
+                "Name": "go_phocus_client"
+            },
+            "Retries": 5
+        },
+        "Messages": {
+            "Read": {
+                "TimeoutSeconds": 2
+            }
+        },
+        "DelaySeconds": 15,
+        "RandDelaySeconds": 5,
+        "MinDelaySeconds": 5,
+        "Profiling": false
+    }`
+
+	reader := strings.NewReader(configJSON)
+	configuration, err := ParseConfig(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, "example.com", configuration.Connection.IP.Host)
+	assert.Equal(t, 1080, configuration.Connection.IP.Port)
+	assert.Equal(t, "192.168.1.1", configuration.MQTT.Host)
+	assert.Equal(t, 1883, configuration.MQTT.Port)
+	assert.Equal(t, "go_phocus_client", configuration.MQTT.Client.Name)
 	assert.Equal(t, 5, configuration.MQTT.Retries)
 	assert.Equal(t, 2, configuration.Messages.Read.TimeoutSeconds)
 	assert.Equal(t, 2*time.Second, time.Duration(configuration.Messages.Read.TimeoutSeconds)*time.Second)

--- a/messages/QID.go
+++ b/messages/QID.go
@@ -8,17 +8,17 @@ import (
 	"strings"
 	"time"
 
-	phocus_crc "github.com/wolffshots/phocus/v2/crc"
-	phocus_mqtt "github.com/wolffshots/phocus/v2/mqtt"
-	phocus_serial "github.com/wolffshots/phocus/v2/serial"
+	comms "github.com/wolffshots/phocus/v2/comms"
+	crc "github.com/wolffshots/phocus/v2/crc"
+	mqtt "github.com/wolffshots/phocus/v2/mqtt"
 )
 
 type QIDResponse struct {
 	SerialNumber string
 }
 
-func SendQID(port phocus_serial.Port, payload interface{}) (int, error) {
-	written, err := port.Write(port.Port, "QID")
+func SendQID(port comms.Port, payload interface{}) (int, error) {
+	written, err := port.Write("QID")
 	if err != nil {
 		return -1, err
 	} else {
@@ -27,8 +27,8 @@ func SendQID(port phocus_serial.Port, payload interface{}) (int, error) {
 	}
 }
 
-func ReceiveQID(port phocus_serial.Port, timeout time.Duration) (string, error) {
-	response, err := port.Read(port.Port, timeout)
+func ReceiveQID(port comms.Port, timeout time.Duration) (string, error) {
+	response, err := port.Read(timeout)
 	log.Printf("%s\n", response)
 	if err != nil || response == "" {
 		log.Printf("Failed to read from serial with: %v\n", err)
@@ -39,7 +39,7 @@ func ReceiveQID(port phocus_serial.Port, timeout time.Duration) (string, error) 
 }
 
 func VerifyQID(response string) (string, error) {
-	if phocus_crc.Verify(response) {
+	if crc.Verify(response) {
 		// return
 		// TODO add check for length
 		log.Printf("Serial number queried: %s\n", response)
@@ -50,7 +50,7 @@ func VerifyQID(response string) (string, error) {
 		}
 		actual := response[len(response)-3 : len(response)-1] // 2 bytes of crc
 		remainder := response[:len(response)-3]               // actual response
-		wanted := phocus_crc.Checksum(remainder)              // response calculated on response data
+		wanted := crc.Checksum(remainder)                     // response calculated on response data
 		message := fmt.Sprintf("invalid response from QID: CRC should have been %x but was %x", wanted, actual)
 		log.Println(message)
 		return "", errors.New(message)
@@ -74,9 +74,9 @@ func EncodeQID(response *QIDResponse) string {
 	return string(jsonQIDResponse)
 }
 
-func PublishQID(client phocus_mqtt.Client, response *QIDResponse) error {
+func PublishQID(client mqtt.Client, response *QIDResponse) error {
 	jsonResponse := EncodeQID(response)
-	err := phocus_mqtt.Send(client, "phocus/stats/qid", 0, true, jsonResponse, 10)
+	err := mqtt.Send(client, "phocus/stats/qid", 0, true, jsonResponse, 10)
 	if err != nil {
 		log.Printf("MQTT send of %s failed with: %v\ntype of thing sent was: %T", "QID", err, jsonResponse)
 	} else {

--- a/messages/QPGSn.go
+++ b/messages/QPGSn.go
@@ -8,9 +8,9 @@ import (
 	"strings"       // string manipulation
 	"time"          // sleeping
 
-	phocus_crc "github.com/wolffshots/phocus/v2/crc"   // checksum calculations
-	phocus_mqtt "github.com/wolffshots/phocus/v2/mqtt" // comms with mqtt broker
-	phocus_serial "github.com/wolffshots/phocus/v2/serial"
+	comms "github.com/wolffshots/phocus/v2/comms" // common types for comms
+	crc "github.com/wolffshots/phocus/v2/crc"     // checksum calculations
+	mqtt "github.com/wolffshots/phocus/v2/mqtt"   // comms with mqtt broker
 )
 
 type OperationMode string
@@ -144,11 +144,11 @@ type QPGSnResponse struct {
 	Checksum                            string
 }
 
-func SendQPGSn(port phocus_serial.Port, payload interface{}) (int, error) {
+func SendQPGSn(port comms.Port, payload interface{}) (int, error) {
 	switch payload.(type) {
 	case int:
 		query := fmt.Sprintf("QPGS%d", payload)
-		written, err := port.Write(port.Port, query)
+		written, err := port.Write(query)
 		if err != nil {
 			return -1, err
 		} else {
@@ -159,7 +159,7 @@ func SendQPGSn(port phocus_serial.Port, payload interface{}) (int, error) {
 		return -1, errors.New("qpgsn does not support string payloads")
 	default:
 		log.Println("Payload type for QPGSn was not handled, proceeding as QPGS0")
-		written, err := port.Write(port.Port, "QPGS0")
+		written, err := port.Write("QPGS0")
 		if err != nil {
 			return -1, err
 		} else {
@@ -169,9 +169,9 @@ func SendQPGSn(port phocus_serial.Port, payload interface{}) (int, error) {
 	}
 }
 
-func ReceiveQPGSn(port phocus_serial.Port, timeout time.Duration, inverterNum int) (string, error) {
+func ReceiveQPGSn(port comms.Port, timeout time.Duration, inverterNum int) (string, error) {
 	// read from port
-	response, err := port.Read(port.Port, timeout)
+	response, err := port.Read(timeout)
 	log.Printf("%s\n", response)
 	// verify
 	if err != nil || response == "" {
@@ -183,7 +183,7 @@ func ReceiveQPGSn(port phocus_serial.Port, timeout time.Duration, inverterNum in
 }
 
 func VerifyQPGSn(response string, inverterNum int) (string, error) {
-	if phocus_crc.Verify(response) {
+	if crc.Verify(response) {
 		return response, nil
 	} else {
 		if len(response) < 3 {
@@ -191,7 +191,7 @@ func VerifyQPGSn(response string, inverterNum int) (string, error) {
 		}
 		actual := response[len(response)-3 : len(response)-1]
 		remainder := response[:len(response)-3]
-		wanted := phocus_crc.Checksum(remainder)
+		wanted := crc.Checksum(remainder)
 		message := fmt.Sprintf("invalid response from QPGS%d: CRC should have been %x but was %x", inverterNum, wanted, actual)
 		log.Println(message)
 		return "", errors.New(message)
@@ -263,9 +263,9 @@ func EncodeQPGSn(response *QPGSnResponse) string {
 	return string(jsonQPGSnResponse)
 }
 
-func PublishQPGSn(client phocus_mqtt.Client, response *QPGSnResponse, inverterNum int) error {
+func PublishQPGSn(client mqtt.Client, response *QPGSnResponse, inverterNum int) error {
 	jsonResponse := EncodeQPGSn(response)
-	err := phocus_mqtt.Send(client, fmt.Sprintf("phocus/stats/qpgs%d", inverterNum), 0, false, string(jsonResponse), 10)
+	err := mqtt.Send(client, fmt.Sprintf("phocus/stats/qpgs%d", inverterNum), 0, false, string(jsonResponse), 10)
 	if err != nil {
 		log.Printf("MQTT send of QPGS%d failed with: %v\ntype of thing sent was: %T", inverterNum, err, jsonResponse)
 	} else {

--- a/messages/QPGSn_test.go
+++ b/messages/QPGSn_test.go
@@ -11,91 +11,104 @@ import (
 	"github.com/stretchr/testify/assert"
 	phocus_crc "github.com/wolffshots/phocus/v2/crc"
 	phocus_serial "github.com/wolffshots/phocus/v2/serial"
-	"go.bug.st/serial"
 )
 
 func TestQPGSn(t *testing.T) {
-	cmd := StartCmd("socat", "PTY,link=./qpgsn1,raw,echo=1,crnl", "PTY,link=./qpgsn2,raw,echo=1,crnl")
+	cmd := StartCmd("socat", "-d", "-d", "PTY,link=./qpgsn1,raw,echo=0,crnl", "PTY,link=./qpgsn2,raw,echo=0,crnl")
 	defer TerminateCmd(cmd)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(51 * time.Millisecond)
 
 	t.Run("TestSendQPGSn", func(t *testing.T) {
 		// setup virtual port
-		port1, err := phocus_serial.Setup("./qpgsn1", 2400, 1)
+		serialPort := phocus_serial.Port{
+			Path:    "./qpgsn1",
+			Baud:    9600,
+			Retries: 1,
+		}
+		commonPort1, err := serialPort.Open()
 		assert.NoError(t, err)
 
 		// valid write to virtual port
-		written, err := SendQPGSn(port1, nil)
+		written, err := SendQPGSn(commonPort1, nil)
 		assert.Equal(t, 8, written)
 		assert.NoError(t, err)
 
 		// valid write to virtual port
-		written, err = SendQPGSn(port1, 1)
+		written, err = SendQPGSn(commonPort1, 1)
 		assert.Equal(t, 8, written)
 		assert.NoError(t, err)
 
 		// invalid write to virtual port with string payload
-		written, err = SendQPGSn(port1, "1")
+		written, err = SendQPGSn(commonPort1, "1")
 		assert.Equal(t, -1, written)
 		assert.Equal(t, errors.New("qpgsn does not support string payloads"), err)
 
-		port1.Port.Close()
-		port1.Port = nil
+		err = commonPort1.Close()
+		assert.NoError(t, err)
 
 		// invalid write
-		written, err = SendQPGSn(port1, nil)
+		written, err = SendQPGSn(commonPort1, nil)
 		assert.Equal(t, -1, written)
 		assert.Equal(t, errors.New("port is nil on write"), err)
 
 		// invalid write
-		written, err = SendQPGSn(port1, "1")
+		written, err = SendQPGSn(commonPort1, "1")
 		assert.Equal(t, -1, written)
 		assert.Equal(t, errors.New("qpgsn does not support string payloads"), err)
 
 		// invalid write
-		written, err = SendQPGSn(port1, 1)
+		written, err = SendQPGSn(commonPort1, 1)
 		assert.Equal(t, -1, written)
 		assert.Equal(t, errors.New("port is nil on write"), err)
 	})
 
 	t.Run("TestReceiveQPGSn", func(t *testing.T) {
 		// setup virtual port
-		port1, err := phocus_serial.Setup("./qpgsn1", 2400, 1)
+		serialPort1 := phocus_serial.Port{
+			Path:    "./qpgsn1",
+			Baud:    9600,
+			Retries: 1,
+		}
+		commonPort1, err := serialPort1.Open()
 		assert.NoError(t, err)
+		defer commonPort1.Close()
+
+		serialPort2 := phocus_serial.Port{
+			Path:    "./qpgsn2",
+			Baud:    9600,
+			Retries: 1,
+		}
+		commonPort2, err := serialPort2.Open()
+		assert.NoError(t, err)
+
+		_, _ = commonPort2.Read(10 * time.Millisecond) // make sure it is empty when writing
 
 		// valid read from virtual port
 		// should time out
-		response, err := ReceiveQPGSn(port1, 0*time.Millisecond, 0)
+		response, err := ReceiveQPGSn(commonPort2, 0*time.Millisecond, 0)
 		assert.Equal(t, "", response)
 		assert.Equal(t, errors.New("read returned nothing"), err)
 
-		port1.Port.Close()
-		port1.Port = nil
+		err = commonPort2.Close()
+		assert.NoError(t, err)
 
 		// invalid read
-		response, err = ReceiveQPGSn(port1, 10*time.Millisecond, 1)
+		response, err = ReceiveQPGSn(commonPort2, 10*time.Millisecond, 1)
 		assert.Equal(t, "", response)
 		assert.Equal(t, errors.New("port is nil on read"), err)
 
-		port1.Read = func(port serial.Port, timeout time.Duration) (string, error) {
-			return "some response\xea\xac\r", nil
-		}
+		commonPort2, err = serialPort2.Open()
+		assert.NoError(t, err)
+		defer commonPort2.Close()
 
 		// valid read from virtual port
 		// should respond
-		response, err = ReceiveQPGSn(port1, 10*time.Millisecond, 0)
-		assert.Equal(t, "some response\xea\xac\r", response)
+		written, err := SendQPGSn(commonPort1, 1) // 5
+		assert.Equal(t, 8, written)               // 5 + 2 (crc) + 1 (cr)
 		assert.NoError(t, err)
-
-		port1.Read = func(port serial.Port, timeout time.Duration) (string, error) {
-			return "", errors.New("some error")
-		}
-
-		// valid read from virtual port
-		// should respond with err
-		response, err = ReceiveQPGSn(port1, 0*time.Millisecond, 0)
-		assert.Equal(t, "", response)
-		assert.Equal(t, errors.New("some error"), err)
+		response, err = ReceiveQPGSn(commonPort2, 10*time.Millisecond, 0)
+		assert.Equal(t, phocus_crc.Encode("QPGS1"), response)
+		assert.NoError(t, err)
 	})
 
 	t.Run("TestVerifyQPGSn", func(t *testing.T) {

--- a/messages/generic.go
+++ b/messages/generic.go
@@ -8,19 +8,19 @@ import (
 	"strings"
 	"time"
 
-	phocus_crc "github.com/wolffshots/phocus/v2/crc"
-	phocus_mqtt "github.com/wolffshots/phocus/v2/mqtt"
-	phocus_serial "github.com/wolffshots/phocus/v2/serial"
+	comms "github.com/wolffshots/phocus/v2/comms"
+	crc "github.com/wolffshots/phocus/v2/crc"
+	mqtt "github.com/wolffshots/phocus/v2/mqtt"
 )
 
 type GenericResponse struct {
 	Result string
 }
 
-func SendGeneric(port phocus_serial.Port, command string, payload interface{}) (int, error) {
+func SendGeneric(port comms.Port, command string, payload interface{}) (int, error) {
 	switch payload.(type) {
 	case int:
-		written, err := port.Write(port.Port, fmt.Sprintf("%s%d", command, payload))
+		written, err := port.Write(fmt.Sprintf("%s%d", command, payload))
 		if err != nil {
 			return -1, err
 		} else {
@@ -28,7 +28,7 @@ func SendGeneric(port phocus_serial.Port, command string, payload interface{}) (
 			return written, nil
 		}
 	case string:
-		written, err := port.Write(port.Port, fmt.Sprintf("%s%s", command, payload))
+		written, err := port.Write(fmt.Sprintf("%s%s", command, payload))
 		if err != nil {
 			return -1, err
 		} else {
@@ -36,7 +36,7 @@ func SendGeneric(port phocus_serial.Port, command string, payload interface{}) (
 			return written, nil
 		}
 	default:
-		written, err := port.Write(port.Port, command)
+		written, err := port.Write(command)
 		if err != nil {
 			return -1, err
 		} else {
@@ -46,9 +46,9 @@ func SendGeneric(port phocus_serial.Port, command string, payload interface{}) (
 	}
 }
 
-func ReceiveGeneric(port phocus_serial.Port, command string, timeout time.Duration) (string, error) {
+func ReceiveGeneric(port comms.Port, command string, timeout time.Duration) (string, error) {
 	// read from port
-	response, err := port.Read(port.Port, timeout)
+	response, err := port.Read(timeout)
 	log.Printf("%s\n", response)
 	// verify
 	if err != nil || response == "" {
@@ -60,7 +60,7 @@ func ReceiveGeneric(port phocus_serial.Port, command string, timeout time.Durati
 }
 
 func VerifyGeneric(response string, command string) (string, error) {
-	if phocus_crc.Verify(response) {
+	if crc.Verify(response) {
 		return response, nil
 	} else {
 		if len(response) < 3 {
@@ -68,7 +68,7 @@ func VerifyGeneric(response string, command string) (string, error) {
 		}
 		actual := response[len(response)-3 : len(response)-1] // 2 bytes of crc
 		remainder := response[:len(response)-3]               // actual response
-		wanted := phocus_crc.Checksum(remainder)              // response calculated on response data
+		wanted := crc.Checksum(remainder)                     // response calculated on response data
 		message := fmt.Sprintf("invalid response from %s: CRC should have been %x but was %x", command, wanted, actual)
 		log.Println(message)
 		return "", errors.New(message)
@@ -90,9 +90,9 @@ func EncodeGeneric(response *GenericResponse) string {
 	return string(jsonGenericResponse)
 }
 
-func PublishGeneric(client phocus_mqtt.Client, response *GenericResponse, command string) error {
+func PublishGeneric(client mqtt.Client, response *GenericResponse, command string) error {
 	jsonResponse := EncodeGeneric(response)
-	err := phocus_mqtt.Send(client, "phocus/stats/generic", 0, true, jsonResponse, 10)
+	err := mqtt.Send(client, "phocus/stats/generic", 0, true, jsonResponse, 10)
 	if err != nil {
 		log.Printf("MQTT send of %s failed with: %v\ntype of thing sent was: %T", command, err, jsonResponse)
 	} else {

--- a/messages/generic_test.go
+++ b/messages/generic_test.go
@@ -8,46 +8,47 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	phocus_crc "github.com/wolffshots/phocus/v2/crc"
+	crc "github.com/wolffshots/phocus/v2/crc"
 	phocus_serial "github.com/wolffshots/phocus/v2/serial"
-	"go.bug.st/serial"
 )
 
 func TestGeneric(t *testing.T) {
-	cmd := StartCmd("socat", "PTY,link=./generic1,raw,echo=1,crnl", "PTY,link=./generic2,raw,echo=1,crnl")
+	cmd := StartCmd("socat", "-d", "-d", "PTY,link=./generic1,raw,echo=0,crnl", "PTY,link=./generic2,raw,echo=0,crnl")
 	defer TerminateCmd(cmd)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(51 * time.Millisecond)
 
 	t.Run("TestSendGeneric", func(t *testing.T) {
-		// start virtual port
-		time.Sleep(51 * time.Millisecond)
-
 		// setup virtual port
-		port1, err := phocus_serial.Setup("./generic1", 2400, 1)
+		serialPort := phocus_serial.Port{
+			Path:    "./generic1",
+			Baud:    9600,
+			Retries: 1,
+		}
+		commonPort1, err := serialPort.Open()
 		assert.NoError(t, err)
 
 		// valid write to virtual port
-		written, err := SendGeneric(port1, "GENERIC", nil)
+		written, err := SendGeneric(commonPort1, "GENERIC", nil)
 		assert.Equal(t, 10, written)
 		assert.NoError(t, err)
-		written, err = SendGeneric(port1, "GENERIC", 1)
+		written, err = SendGeneric(commonPort1, "GENERIC", 1)
 		assert.Equal(t, 11, written)
 		assert.NoError(t, err)
-		written, err = SendGeneric(port1, "GENERIC", "1")
+		written, err = SendGeneric(commonPort1, "GENERIC", "1")
 		assert.Equal(t, 11, written)
 		assert.NoError(t, err)
 
-		port1.Port.Close()
-		port1.Port = nil
+		err = commonPort1.Close()
+		assert.NoError(t, err)
 
 		// invalid write
-		written, err = SendGeneric(port1, "GENERIC", nil)
+		written, err = SendGeneric(commonPort1, "GENERIC", nil)
 		assert.Equal(t, -1, written)
 		assert.Equal(t, errors.New("port is nil on write"), err)
-		written, err = SendGeneric(port1, "GENERIC", 1)
+		written, err = SendGeneric(commonPort1, "GENERIC", 1)
 		assert.Equal(t, -1, written)
 		assert.Equal(t, errors.New("port is nil on write"), err)
-		written, err = SendGeneric(port1, "GENERIC", "1")
+		written, err = SendGeneric(commonPort1, "GENERIC", "1")
 		assert.Equal(t, -1, written)
 		assert.Equal(t, errors.New("port is nil on write"), err)
 	})
@@ -56,43 +57,52 @@ func TestGeneric(t *testing.T) {
 		// start virtual port
 		time.Sleep(51 * time.Millisecond)
 
-		// setup virtual port
-		port1, err := phocus_serial.Setup("./generic1", 2400, 1)
+		// setup virtual ports
+		serialPort1 := phocus_serial.Port{
+			Path:    "./generic1",
+			Baud:    9600,
+			Retries: 1,
+		}
+		commonPort1, err := serialPort1.Open()
 		assert.NoError(t, err)
+		defer commonPort1.Close()
+
+		serialPort2 := phocus_serial.Port{
+			Path:    "./generic2",
+			Baud:    9600,
+			Retries: 1,
+		}
+		commonPort2, err := serialPort2.Open()
+		assert.NoError(t, err)
+
+		_, _ = commonPort2.Read(10 * time.Millisecond) // make sure it is empty when writing
 
 		// valid read from virtual port
 		// should time out
-		response, err := ReceiveGeneric(port1, "GENERIC", 0*time.Millisecond)
+		response, err := ReceiveGeneric(commonPort2, "GENERIC", 0*time.Millisecond)
 		assert.Equal(t, "", response)
 		assert.Equal(t, errors.New("read returned nothing"), err)
 
-		port1.Port.Close()
-		port1.Port = nil
+		err = commonPort2.Close()
+		assert.NoError(t, err)
 
 		// invalid read
-		response, err = ReceiveGeneric(port1, "GENERIC", 10*time.Millisecond)
+		response, err = ReceiveGeneric(commonPort2, "GENERIC", 10*time.Millisecond)
 		assert.Equal(t, "", response)
 		assert.Equal(t, errors.New("port is nil on read"), err)
 
-		port1.Read = func(port serial.Port, timeout time.Duration) (string, error) {
-			return "some response\xea\xac\r", nil
-		}
+		commonPort2, err = serialPort2.Open()
+		assert.NoError(t, err)
+		defer commonPort2.Close()
 
 		// valid read from virtual port
 		// should respond
-		response, err = ReceiveGeneric(port1, "some message", 10*time.Millisecond)
-		assert.Equal(t, "some response\xea\xac\r", response)
+		written, err := SendGeneric(commonPort1, "some message", nil) // 12
+		assert.Equal(t, 15, written)                                  // 12 + 2 (crc) + 1 (cr)
 		assert.NoError(t, err)
-
-		port1.Read = func(port serial.Port, timeout time.Duration) (string, error) {
-			return "", errors.New("some error")
-		}
-
-		// valid read from virtual port
-		// should respond with err
-		response, err = ReceiveGeneric(port1, "some message", 0*time.Millisecond)
-		assert.Equal(t, "", response)
-		assert.Equal(t, errors.New("some error"), err)
+		response, err = ReceiveGeneric(commonPort2, "some message", 10*time.Millisecond)
+		assert.Equal(t, "some message\xbe\x0f\r", response)
+		assert.NoError(t, err)
 	})
 
 	t.Run("TestVerifyGeneric", func(t *testing.T) {
@@ -135,9 +145,9 @@ func TestGeneric(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, want, actual)
 
-		assert.Equal(t, false, phocus_crc.Verify(input[1:]))
-		assert.Equal(t, true, phocus_crc.Verify(input))
-		assert.Equal(t, uint16(0x2e2a), phocus_crc.Checksum(input[:len(input)-3]))
+		assert.Equal(t, false, crc.Verify(input[1:]))
+		assert.Equal(t, true, crc.Verify(input))
+		assert.Equal(t, uint16(0x2e2a), crc.Checksum(input[:len(input)-3]))
 
 		// test grabbed input
 		input = "(ACK\x94\x7b\r"

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	phocus_mqtt "github.com/wolffshots/phocus/v2/mqtt"
-	phocus_serial "github.com/wolffshots/phocus/v2/serial" // comms with inverter
+	comms "github.com/wolffshots/phocus/v2/comms"
+	mqtt "github.com/wolffshots/phocus/v2/mqtt"
 )
 
 // Message is the shape of a message for phocus to interpret and handle queuing of
@@ -21,8 +21,8 @@ type Message struct {
 // Interpret converts the generic `phocus` message into a specific inverter message
 // TODO add even more generalisation and separated implementation details here
 func Interpret(
-	client phocus_mqtt.Client,
-	port phocus_serial.Port,
+	client mqtt.Client,
+	port comms.Port,
 	input Message,
 	readTimeout time.Duration,
 ) (*QPGSnResponse, error) {

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	phocus_serial "github.com/wolffshots/phocus/v2/serial"
-	"go.bug.st/serial"
 )
 
 func Run(cmd *exec.Cmd) {
@@ -37,69 +36,112 @@ func TerminateCmd(cmd *exec.Cmd) {
 		panic(fmt.Sprintf("command isn't running: %v", cmd))
 	}
 }
+
 func TestMesages(t *testing.T) {
-	cmd := StartCmd("socat", "PTY,link=./messages1,raw,echo=1,crnl", "PTY,link=./messages2,raw,echo=1,crnl")
+	cmd := StartCmd("socat", "-d", "-d", "PTY,link=./messages1,raw,echo=0,crnl", "PTY,link=./messages2,raw,echo=0,crnl")
 	defer TerminateCmd(cmd)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(51 * time.Millisecond)
 
 	t.Run("TestInterpretWriteErrors", func(t *testing.T) {
 		var client mqtt.Client
 
-		port1, err := phocus_serial.Setup("./messages1", 2400, 5)
+		// setup virtual port
+		serialPort2 := phocus_serial.Port{
+			Path:    "./messages2",
+			Baud:    9600,
+			Retries: 1,
+		}
+		commonPort2, err := serialPort2.Open()
 		assert.NoError(t, err)
-		assert.NoError(t, port1.Port.Close())
-		port1.Port = nil
 
-		qpgsnresponse, err := Interpret(client, port1, Message{uuid.New(), "QPGS1", ""}, 0*time.Second)
+		err = commonPort2.Close()
+		assert.NoError(t, err)
+
+		qpgsnresponse, err := Interpret(client, commonPort2, Message{uuid.New(), "QPGS1", ""}, 0*time.Second)
 		assert.EqualError(t, err, "port is nil on write")
 		assert.Nil(t, qpgsnresponse)
 
-		qpgsnresponse, err = Interpret(client, port1, Message{uuid.New(), "QPGS2", ""}, 0*time.Second)
+		qpgsnresponse, err = Interpret(client, commonPort2, Message{uuid.New(), "QPGS2", ""}, 0*time.Second)
 		assert.EqualError(t, err, "port is nil on write")
 		assert.Nil(t, qpgsnresponse)
 
-		qpgsnresponse, err = Interpret(client, port1, Message{uuid.New(), "QID", ""}, 0*time.Second)
+		qpgsnresponse, err = Interpret(client, commonPort2, Message{uuid.New(), "QID", ""}, 0*time.Second)
 		assert.EqualError(t, err, "port is nil on write")
 		assert.Nil(t, qpgsnresponse)
 
-		qpgsnresponse, err = Interpret(client, port1, Message{uuid.New(), "SOMETHING_ELSE", ""}, 0*time.Second)
+		qpgsnresponse, err = Interpret(client, commonPort2, Message{uuid.New(), "SOMETHING_ELSE", ""}, 0*time.Second)
 		assert.EqualError(t, err, "port is nil on write")
 		assert.Nil(t, qpgsnresponse)
 	})
 
 	t.Run("TestInterpretReadErrors", func(t *testing.T) {
 		var client mqtt.Client
-		port2, err := phocus_serial.Setup("./messages1", 2400, 5)
+		// setup virtual port
+		serialPort2 := phocus_serial.Port{
+			Path:    "./messages2",
+			Baud:    9600,
+			Retries: 1,
+		}
+		commonPort2, err := serialPort2.Open()
 		assert.NoError(t, err)
-		defer port2.Port.Close()
 
-		qpgsnresponse, err := Interpret(client, port2, Message{uuid.New(), "QPGS1", ""}, 0*time.Second)
+		defer func() {
+			err := commonPort2.Close()
+			assert.NoError(t, err)
+		}()
+
+		qpgsnresponse, err := Interpret(client, commonPort2, Message{uuid.New(), "QPGS1", ""}, 0*time.Second)
 		assert.EqualError(t, err, "read returned nothing")
 		assert.Nil(t, qpgsnresponse)
 
-		qpgsnresponse, err = Interpret(client, port2, Message{uuid.New(), "QPGS2", ""}, 0*time.Second)
+		qpgsnresponse, err = Interpret(client, commonPort2, Message{uuid.New(), "QPGS2", ""}, 0*time.Second)
 		assert.EqualError(t, err, "read returned nothing")
 		assert.Nil(t, qpgsnresponse)
 
-		qpgsnresponse, err = Interpret(client, port2, Message{uuid.New(), "QID", ""}, 0*time.Second)
+		qpgsnresponse, err = Interpret(client, commonPort2, Message{uuid.New(), "QID", ""}, 0*time.Second)
 		assert.EqualError(t, err, "read returned nothing")
 		assert.Nil(t, qpgsnresponse)
 
-		qpgsnresponse, err = Interpret(client, port2, Message{uuid.New(), "SOMETHING_ELSE", ""}, 0*time.Second)
+		qpgsnresponse, err = Interpret(client, commonPort2, Message{uuid.New(), "SOMETHING_ELSE", ""}, 0*time.Second)
 		assert.EqualError(t, err, "read returned nothing")
 		assert.Nil(t, qpgsnresponse)
 	})
 
 	t.Run("TestInterpret", func(t *testing.T) {
 		var client mqtt.Client
-		port1, err := phocus_serial.Setup("./messages1", 2400, 5)
-		assert.NoError(t, err)
-		defer port1.Port.Close()
-
-		port1.Read = func(port serial.Port, timeout time.Duration) (string, error) {
-			return "1 92932004102443 B 00 237.0 50.01 000.0 00.00 0483 0387 009 51.1 000 069 020.4 000 00942 00792 007 00000010 1 1 060 080 10 00.0 006\xf2\x2d\r", nil
+		serialPort1 := phocus_serial.Port{
+			Path:    "./messages1",
+			Baud:    9600,
+			Retries: 1,
 		}
-		qpgsnresponse, err := Interpret(client, port1, Message{uuid.New(), "QPGS1", ""}, 0*time.Second)
+		commonPort1, err := serialPort1.Open()
+		assert.NoError(t, err)
+
+		serialPort2 := phocus_serial.Port{
+			Path:    "./messages2",
+			Baud:    9600,
+			Retries: 1,
+		}
+		commonPort2, err := serialPort2.Open()
+		assert.NoError(t, err)
+
+		defer func() {
+			err := commonPort1.Close()
+			assert.NoError(t, err)
+			err = commonPort2.Close()
+			assert.NoError(t, err)
+		}()
+
+		// commonPort2.Read = func(port serial.Port, timeout time.Duration) (string, error) {
+		// 	return "1 92932004102443 B 00 237.0 50.01 000.0 00.00 0483 0387 009 51.1 000 069 020.4 000 00942 00792 007 00000010 1 1 060 080 10 00.0 006\xf2\x2d\r", nil
+		// }
+		written, err := commonPort1.Write("1 92932004102443 B 00 237.0 50.01 000.0 00.00 0483 0387 009 51.1 000 069 020.4 000 00942 00792 007 00000010 1 1 060 080 10 00.0 006") // \xf2\x2d\r
+		assert.Equal(t, 134, written)
+		assert.NoError(t, err)
+
+		time.Sleep(10 * time.Millisecond)
+
+		qpgsnresponse, err := Interpret(client, commonPort2, Message{uuid.New(), "QPGS1", ""}, 0*time.Second)
 		assert.EqualError(t, err, "client not defined in send")
 		assert.Equal(t, QPGSnResponse{InverterNumber: 1,
 			OtherUnits:                          true,
@@ -139,10 +181,16 @@ func TestMesages(t *testing.T) {
 			*qpgsnresponse,
 		)
 
-		port1.Read = func(port serial.Port, timeout time.Duration) (string, error) {
-			return "1 92932004102453 B 00 237.0 50.01 000.0 00.00 0483 0387 009 51.1 000 069 020.4 000 00942 00792 007 00000010 1 1 060 080 10 00.0 006\x9f\x50\r", nil
-		}
-		qpgsnresponse, err = Interpret(client, port1, Message{uuid.New(), "QPGS2", ""}, 0*time.Second)
+		// commonPort2.Read = func(port serial.Port, timeout time.Duration) (string, error) {
+		// 	return "1 92932004102453 B 00 237.0 50.01 000.0 00.00 0483 0387 009 51.1 000 069 020.4 000 00942 00792 007 00000010 1 1 060 080 10 00.0 006\x9f\x50\r", nil
+		// }
+		written, err = commonPort1.Write("1 92932004102453 B 00 237.0 50.01 000.0 00.00 0483 0387 009 51.1 000 069 020.4 000 00942 00792 007 00000010 1 1 060 080 10 00.0 006") // \xf2\x2d\r
+		assert.Equal(t, 134, written)
+		assert.NoError(t, err)
+
+		time.Sleep(10 * time.Millisecond)
+
+		qpgsnresponse, err = Interpret(client, commonPort2, Message{uuid.New(), "QPGS2", ""}, 0*time.Second)
 		assert.EqualError(t, err, "client not defined in send")
 		assert.Equal(t, QPGSnResponse{InverterNumber: 2,
 			OtherUnits:                          true,
@@ -182,17 +230,29 @@ func TestMesages(t *testing.T) {
 			*qpgsnresponse,
 		)
 
-		port1.Read = func(port serial.Port, timeout time.Duration) (string, error) {
-			return "92932004102453\xa7\x4a\r", nil
-		}
-		qpgsnresponse, err = Interpret(client, port1, Message{uuid.New(), "QID", ""}, 0*time.Second)
+		// commonPort2.Read = func(port serial.Port, timeout time.Duration) (string, error) {
+		// 	return "92932004102453\xa7\x4a\r", nil
+		// }
+		written, err = commonPort1.Write("92932004102453") // \xa7\x4a\r
+		assert.Equal(t, 17, written)
+		assert.NoError(t, err)
+
+		time.Sleep(10 * time.Millisecond)
+
+		qpgsnresponse, err = Interpret(client, commonPort2, Message{uuid.New(), "QID", ""}, 0*time.Second)
 		assert.EqualError(t, err, "client not defined in send")
 		assert.Nil(t, qpgsnresponse)
 
-		port1.Read = func(port serial.Port, timeout time.Duration) (string, error) {
-			return "SOME_RESPONSE\xb2\xb2\r", nil
-		}
-		qpgsnresponse, err = Interpret(client, port1, Message{uuid.New(), "SOME_MESSAGE", ""}, 0*time.Second)
+		// commonPort2.Read = func(port serial.Port, timeout time.Duration) (string, error) {
+		// 	return "SOME_RESPONSE\xb2\xb2\r", nil
+		// }
+		written, err = commonPort1.Write("SOME_RESPONSE") // \xb2\xb2\r
+		assert.Equal(t, 16, written)
+		assert.NoError(t, err)
+
+		time.Sleep(10 * time.Millisecond)
+
+		qpgsnresponse, err = Interpret(client, commonPort2, Message{uuid.New(), "SOME_MESSAGE", ""}, 0*time.Second)
 		assert.EqualError(t, err, "client not defined in send")
 		assert.Nil(t, qpgsnresponse)
 	})

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -4,97 +4,118 @@ package phocus_serial
 
 import (
 	"errors" // creating custom err messages
-	"fmt"    // formatting
+	"fmt"    // string formatting
 	"log"    // logging
 	"time"   // timeouts
 
-	crc "github.com/wolffshots/phocus/v2/crc" // checksum generation
-	"go.bug.st/serial"                        // rs232 serial
+	comms "github.com/wolffshots/phocus/v2/comms" // common types for comms
+	crc "github.com/wolffshots/phocus/v2/crc"     // checksum generation
+	serial "go.bug.st/serial"                     // rs232 serial
 )
 
-type Writer func(port serial.Port, input string) (int, error)
-type Reader func(port serial.Port, timeout time.Duration) (string, error)
+// type Writer func(port serial.Port, input string) (int, error)
+// type Reader func(port serial.Port, timeout time.Duration) (string, error)
 
 // port is the object representing the serial device/connection
 // var port serial.Port
 
 type Port struct {
-	Port  serial.Port
-	Path  string
-	Write Writer
-	Read  Reader
+	Port    *serial.Port
+	Path    string
+	Baud    int
+	Retries int
 }
 
-// Setup opens a connection to the inverter.
+// Open opens a connection to the inverter.
 //
 // Returns the port or an error if the port fails to open.
-func Setup(portPath string, baud int, retries int) (Port, error) {
-	var port serial.Port
+func (sp *Port) Open() (comms.Port, error) {
+	fmt.Printf("Opening serial port: %s\n", sp.Path)
 	var err error
-	for i := 0; i < retries; i++ {
+	var port serial.Port
+	for i := 0; i < sp.Retries; i++ {
 		mode := &serial.Mode{
-			BaudRate: baud,
+			BaudRate: sp.Baud,
 		}
-		port, err = serial.Open(portPath, mode)
+		port, err = serial.Open(sp.Path, mode)
 		if err != nil {
 			log.Printf("Failed to set up serial %d times with err: %v", i+1, err)
 			time.Sleep(50 * time.Millisecond)
 		} else {
+			sp.Port = &port
 			log.Printf("Succeeded to set up serial after %d times", i+1)
 			break
 		}
 	}
-	return Port{
-		Port:  port,
-		Path:  portPath,
-		Write: Write,
-		Read:  Read,
-	}, err
+	return sp, err
 }
 
-// Write a string to the open serial port
-// The input should just be the "payload" string as
-// the CRC is calculated and added to that in Write
-var Write = func(port serial.Port, input string) (int, error) {
-	message := crc.Encode(input)
-	if port == nil {
-		return 0, errors.New("port is nil on write")
+// Close just closes the port
+//
+// Returns the error if there is one
+func (sp *Port) Close() error {
+	fmt.Printf("Closing serial port: %s\n", sp.Path)
+	if sp.Port == nil || sp == nil {
+		return errors.New("serial port was nil on close call")
 	}
-	n, err := port.Write([]byte(message))
-	if err != nil {
-		return -1, err
+	err := (*sp.Port).Close()
+	if err == nil {
+		sp.Port = nil
 	}
-	return n, err
+	return err
 }
 
 // Read from the open serial port until reaching a carriage return, nil or nothing.
 // Takes a duration as an input and times out the read after that long.
 //
 // Returns the read string and the error
-var Read = func(port serial.Port, timeout time.Duration) (string, error) {
+func (sp *Port) Read(timeout time.Duration) (string, error) {
 	log.Printf("Starting read\n")
-	buff := make([]byte, 140)
-	if port == nil {
+	if sp.Port == nil || sp == nil {
+		log.Printf("Port nil on read\n")
 		return "", errors.New("port is nil on read")
 	}
-	port.SetReadTimeout(timeout)
-	var err error
+	buff := make([]byte, 140)
+	err := (*sp.Port).SetReadTimeout(timeout)
+	if err != nil {
+		return "", errors.New("failed to set timeout")
+	}
 	var response string
 	for {
-		n, readErr := port.Read(buff)
+		n, readErr := (*sp.Port).Read(buff)
 		if readErr != nil {
 			log.Printf("Err reading from port: %v", readErr)
 			err = readErr
 			break
 		} else if n == 0 {
-			log.Println("\nEOF")
-			err = errors.New("read returned nothing")
+			log.Println("EOF")
+			if response == "" {
+				err = errors.New("read returned nothing")
+			}
 			break
 		} else if string(buff[:n]) == "\r" {
+			log.Printf("Encountered carriage return\n")
 			response = fmt.Sprintf("%v%v", response, string(buff[:n]))
 			break
 		}
+		log.Printf("Current response: %v\n", string(buff[:n]))
 		response = fmt.Sprintf("%v%v", response, string(buff[:n]))
 	}
 	return response, err
+}
+
+// Write a string to the open serial port
+// The input should just be the "payload" string as
+// the CRC is calculated and added to that in Write
+func (sp *Port) Write(input string) (int, error) {
+	log.Printf("Starting write\n")
+	if sp.Port == nil || sp == nil {
+		return -1, errors.New("port is nil on write")
+	}
+	message := crc.Encode(input)
+	n, err := (*sp.Port).Write([]byte(message))
+	if err != nil {
+		return -1, err
+	}
+	return n, err
 }

--- a/serial/serial_test.go
+++ b/serial/serial_test.go
@@ -43,9 +43,9 @@ func TerminateCmd(cmd *exec.Cmd) {
 }
 
 func TestSerial(t *testing.T) {
-	cmd := StartCmd("socat", "PTY,link=./serial1,raw,echo=1,crnl", "PTY,link=./serial2,raw,echo=1,crnl")
+	cmd := StartCmd("socat", "-d", "-d", "PTY,link=./serial1,raw,echo=0,crnl", "PTY,link=./serial2,raw,echo=0,crnl")
 	defer TerminateCmd(cmd)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(51 * time.Millisecond)
 
 	t.Run("TestSetup", func(t *testing.T) {
 		var buf bytes.Buffer
@@ -54,9 +54,19 @@ func TestSerial(t *testing.T) {
 		defer func() {
 			log.SetOutput(os.Stderr)
 		}()
-		badPort, err := Setup("./bad_port", 2400, 5)
+
+		// sanity check with bug serial
+		_, err := serial.Open("./bad_port", &serial.Mode{BaudRate: 2400})
 		assert.Equal(t, syscall.Errno(0x2), err)
-		assert.Equal(t, "./bad_port", badPort.Path)
+
+		badSerialPort := Port{
+			Path:    "./bad_port",
+			Baud:    2400,
+			Retries: 5,
+		}
+		_, err = badSerialPort.Open()
+		assert.Equal(t, "./bad_port", badSerialPort.Path)
+		assert.NoFileExists(t, "./bad_port")
 		for i, message := range strings.Split(buf.String(), "\n") {
 			if len(message) > 20 {
 				assert.Equal(t, fmt.Sprintf("Failed to set up serial %d times with err: no such file or directory", i+1), message[20:])
@@ -64,15 +74,22 @@ func TestSerial(t *testing.T) {
 				assert.Equal(t, "", message)
 			}
 		}
+		assert.Equal(t, syscall.Errno(0x2), err)
 
 		buf.Reset()
 
 		time.Sleep(51 * time.Millisecond)
 
-		port1, err := Setup("./serial1", 2400, 5)
+		// setup virtual ports
+		serialPort1 := Port{
+			Path:    "./serial1",
+			Baud:    2400,
+			Retries: 5,
+		}
+		commonPort1, err := serialPort1.Open()
 		assert.NoError(t, err)
-		defer port1.Port.Close()
-		assert.Equal(t, "./serial1", port1.Path)
+		defer commonPort1.Close()
+		assert.Equal(t, "./serial1", serialPort1.Path)
 
 		for i, message := range strings.Split(buf.String(), "\n") {
 			if len(message) > 20 {
@@ -84,10 +101,15 @@ func TestSerial(t *testing.T) {
 
 		buf.Reset()
 
-		port2, err := Setup("./serial2", 2400, 5)
+		serialPort2 := Port{
+			Path:    "./serial2",
+			Baud:    2400,
+			Retries: 5,
+		}
+		commonPort2, err := serialPort2.Open()
 		assert.NoError(t, err)
-		defer port2.Port.Close()
-		assert.Equal(t, "./serial2", port2.Path)
+		defer commonPort2.Close()
+		assert.Equal(t, "./serial2", serialPort2.Path)
 
 		for i, message := range strings.Split(buf.String(), "\n") {
 			if len(message) > 20 {
@@ -99,39 +121,78 @@ func TestSerial(t *testing.T) {
 	})
 
 	t.Run("TestWrite", func(t *testing.T) {
-		port1, err := Setup("./serial1", 2400, 5)
+		serialPort1 := Port{
+			Path:    "./serial1",
+			Baud:    2400,
+			Retries: 5,
+		}
+		commonPort1, err := serialPort1.Open()
 		assert.NoError(t, err)
-		written, err := port1.Write(port1.Port, "test")
+		assert.Equal(t, "./serial1", serialPort1.Path)
+
+		written, err := commonPort1.Write("test")
 		assert.Equal(t, 7, written)
 		assert.NoError(t, err)
 
-		port1.Port.Close()
-		written, err = port1.Write(port1.Port, "test")
+		commonPort1.Close()
+		written, err = commonPort1.Write("test")
 		assert.Equal(t, -1, written)
-		assert.Equal(t, syscall.Errno(0x9), err)
-
-		port1.Port = nil
-		written, err = port1.Write(port1.Port, "test")
-		assert.Equal(t, 0, written)
 		assert.Equal(t, errors.New("port is nil on write"), err)
 	})
 
 	t.Run("TestRead", func(t *testing.T) {
-		port1, err := Setup("./serial1", 2400, 5)
+		serialPort1 := Port{
+			Path:    "./serial1",
+			Baud:    2400,
+			Retries: 5,
+		}
+		commonPort1, err := serialPort1.Open()
 		assert.NoError(t, err)
-		read, err := port1.Read(port1.Port, 1*time.Millisecond)
+		assert.Equal(t, "./serial1", serialPort1.Path)
+
+		read, err := commonPort1.Read(1 * time.Millisecond)
 		assert.Equal(t, "", read)
 		assert.Equal(t, errors.New("read returned nothing"), err)
 
-		err = port1.Port.Close()
+		err = commonPort1.Close()
 		assert.NoError(t, err)
-		read, err = port1.Read(port1.Port, 1*time.Millisecond)
-		assert.Equal(t, "", read)
-		assert.Equal(t, serial.PortClosed, err.(*serial.PortError).Code())
-
-		port1.Port = nil
-		read, err = port1.Read(port1.Port, 1*time.Millisecond)
+		read, err = commonPort1.Read(1 * time.Millisecond)
 		assert.Equal(t, "", read)
 		assert.Equal(t, errors.New("port is nil on read"), err)
+	})
+
+	t.Run("TestReadWrite", func(t *testing.T) {
+		serialPort1 := Port{
+			Path:    "./serial1",
+			Baud:    2400,
+			Retries: 5,
+		}
+		commonPort1, err := serialPort1.Open()
+		assert.NoError(t, err)
+		defer commonPort1.Close()
+		assert.Equal(t, "./serial1", serialPort1.Path)
+
+		serialPort2 := Port{
+			Path:    "./serial2",
+			Baud:    2400,
+			Retries: 5,
+		}
+		commonPort2, err := serialPort2.Open()
+		assert.NoError(t, err)
+		defer commonPort2.Close()
+		assert.Equal(t, "./serial2", serialPort2.Path)
+
+		// clear past read
+		_, _ = commonPort2.Read(50 * time.Millisecond)
+
+		written, err := commonPort1.Write("test")
+		assert.Equal(t, 7, written)
+		assert.NoError(t, err)
+
+		time.Sleep(51 * time.Millisecond)
+
+		read, err := commonPort2.Read(50 * time.Millisecond)
+		assert.Equal(t, "test\x9b\x06\r", read)
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
This is in preparation for being able to run the app on a separate device to the one that actually communicates with the inverter. 
The goal is to be able to run this project on my main server with a more beefy system and higher reliability than a Raspberry Pi (which is how it is currently deployed) and replace the Pi with an ESP board running [esphome-stream-server](https://github.com/wolffshots/esphome-stream-server) powered by the serial port directly rather than having to externally power the Pi.

Long term goal is to Dockerise the project (#59) and then I can work on improving efficiency further and implementing more robust healthchecks which can restart the project properly. Currently it just dispatches a command to restart the systemd service when certain issues are encountered.